### PR TITLE
Fixed hosts endpoint response restructure

### DIFF
--- a/proxy/app.py
+++ b/proxy/app.py
@@ -198,7 +198,7 @@ def get_hosts():
 
     for bucket in buckets:
         bucket_name = bucket['name']
-        stats = query_resolvers.fetch_stats_for_host(host=bucket_name, start=start, resolution=resolution)
+        stats = query_resolvers.fetch_stats_for_host(host=bucket_name)
         data = _transform_stats(stats)
         if ' ' in bucket_name:  # TODO: do not tolerate buckets that don't follow naming convention
             data['name'], data['ip'] = bucket_name.split()

--- a/proxy/app.py
+++ b/proxy/app.py
@@ -134,11 +134,12 @@ def create_bucket_for_host():
 def get_hosts():
     start = resolution = None
 
-    try:
-        start = request.args['start']  # query parameter 'start': relative start time of measurements (eg. -1h)
-        resolution = request.args['res']  # query parameter 'res': resolution of measurements (eg. 10s) (but not sure)
-    except BadRequestKeyError as brke:
-        return create_error_response(f"Missing query parameter(s). ({brke})", 400)
+    # for the MVP scope this part is redundant (we only get latest value(s))
+    # try:
+    #     start = request.args['start']  # query parameter 'start': relative start time of measurements (eg. -1h)
+    #     resolution = request.args['res']  # query parameter 'res': resolution of measurements (eg. 10s) (but not sure)
+    # except BadRequestKeyError as brke:
+    #     return create_error_response(f"Missing query parameter(s): \'start\' and \'res\' are required ({brke})", 400)
 
     buckets = bucket_resolvers.fetch_all_buckets()['buckets']
     hosts = {}
@@ -147,39 +148,58 @@ def get_hosts():
         return create_error_response(buckets['message'], buckets['code'])
 
     # transforms flat list of measurement; groups points by: host, _measurement, _field
-    def _filter_stats(list_of_data: list):
+    def _transform_stats(list_of_data: list):
         res = {}
 
+        # rearrange data into correct structure
         for point in list_of_data:
+            _field_list = []
             _mes = point['_measurement']
             _field = point['_field']
-            if _mes == '_measurement':
+            if _mes == '_measurement':  # drop redundant values
                 continue
             if _mes not in res.keys():
                 res[_mes] = {}
             _mes_dict = res[_mes]
-            # if _mes == 'containers':
-            #     pass
-            # else:
-            if _field not in _mes_dict.keys():
-                _mes_dict[_field] = []
-            _field_list = _mes_dict[_field]
+            if _mes == 'containers':
+                container_id = point['id']
+                if container_id not in _mes_dict.keys():
+                    _mes_dict[container_id] = {}
+                container_dict = _mes_dict[container_id]
+                container_dict['id'] = container_id
+                container_dict['name'] = point['name']
+                container_dict['image'] = point['image']
+                container_dict[_field] = {  # TODO remove hardcoded values (or not?)
+                    '_start': point['_start'],
+                    '_stop': point['_stop'],
+                    '_time': point['_time'],
+                    '_value': point['_value']
+                }
+            else:
+                if _field not in _mes_dict.keys():
+                    _mes_dict[_field] = []
+                _field_list = _mes_dict[_field]
 
-            # remove unnecessary key-value pairs
+            # remove redundant key-value pairs
             del point['_measurement']
             del point['_field']
             del point['']
             del point['result']
             del point['table']
-            point = {k: v for k, v in point.items() if v}
+
+            point = {k: v for k, v in point.items() if v}  # drop keys with null (None) values
             _field_list.append(point)
+
+        if 'containers' in res.keys():
+            containers = res['containers']
+            res['containers'] = [val for val in containers.values()]  # transform 'containers' from dict of dicts to list of dicts
 
         return res
 
     for bucket in buckets:
         bucket_name = bucket['name']
         stats = query_resolvers.fetch_stats_for_host(host=bucket_name, start=start, resolution=resolution)
-        data = _filter_stats(stats)
+        data = _transform_stats(stats)
         if ' ' in bucket_name:  # TODO: do not tolerate buckets that don't follow naming convention
             data['name'], data['ip'] = bucket_name.split()
         hosts[bucket_name] = data

--- a/proxy/resolvers/query_resolvers.py
+++ b/proxy/resolvers/query_resolvers.py
@@ -15,19 +15,11 @@ def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
             'Authorization': f'Token {INFLUXDB_TOKEN}'
         },
         json={
-            # "query": f"from(bucket: \"{host}\")\n"
-            #          f"|> range(start: {start})\n"
-            #          f"|> filter(fn: (r) => r[\"_measurement\"] == \"containers\" or r[\"_measurement\"] == \"disk\" or "
-            #             f"r[\"_measurement\"] == \"virtual_memory\")\n|> filter(fn: (r) => r[\"_field\"] == \"used\" or "
-            #             f"r[\"_field\"] == \"total\" or r[\"_field\"] == \"status\" or r[\"_field\"] == \"percent\" or "
-            #             f"r[\"_field\"] == \"name\" or r[\"_field\"] == \"memory_usage\" or r[\"_field\"] == \"image\" or "
-            #             f"r[\"_field\"] == \"id\" or r[\"_field\"] == \"cpu_percentage\")\n"
-            #          f"|> aggregateWindow(every: {resolution}, fn: last, createEmpty: false)\n|> yield(name:\"last\")"
             "query": f"from(bucket: \"{host}\")\n"
                      f"|> range(start: {start})\n"
                      f"|> filter(fn: (r) => r[\"_measurement\"] == \"containers\" or r[\"_measurement\"] == \"disk\" or "
                      f"r[\"_measurement\"] == \"virtual_memory\")\n|> aggregateWindow(every: {resolution}, "
-                        f"fn: last, createEmpty: false)\n|> yield(name:\"last\")"
+                        f"fn: last, createEmpty: false)\n|> last()\n|> yield(name:\"last\")"
         }
     )
 
@@ -38,8 +30,5 @@ def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
     for row in reader:
         json_data.append(row)
     print(json_data)
-    # print(list(reader))
-    # json_data = eval(json.dumps(list(reader)))
-    # print(json_data)
 
     return json_data

--- a/proxy/resolvers/query_resolvers.py
+++ b/proxy/resolvers/query_resolvers.py
@@ -1,6 +1,5 @@
 from utils import INFLUXDB_TOKEN, ENCODING
 import requests
-import json
 import csv
 import io
 
@@ -8,7 +7,7 @@ import io
 # fetches all stats in bucket (host) form InfluxDB
 # https://docs.influxdata.com/influxdb/v2.0/api/#operation/PostQuery
 # https://docs.influxdata.com/influxdb/v2.0/query-data/execute-queries/influx-api/
-def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
+def fetch_stats_for_host(host, org='agh-utc', start="-7d", resolution="10s"):
     response = requests.post(
         url=f'http://influxdb:8086/api/v2/query?org={org}',
         headers={

--- a/proxy/resolvers/query_resolvers.py
+++ b/proxy/resolvers/query_resolvers.py
@@ -24,12 +24,9 @@ def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
     )
 
     csv_data = response.content.decode(ENCODING)
-    print(csv_data)
     reader = csv.DictReader(io.StringIO(csv_data))
     json_data = []
     for row in reader:
-        print(row)
         json_data.append(row)
-    # print(json_data)
 
     return json_data

--- a/proxy/resolvers/query_resolvers.py
+++ b/proxy/resolvers/query_resolvers.py
@@ -28,7 +28,8 @@ def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
     reader = csv.DictReader(io.StringIO(csv_data))
     json_data = []
     for row in reader:
+        print(row)
         json_data.append(row)
-    print(json_data)
+    # print(json_data)
 
     return json_data

--- a/proxy/resolvers/query_resolvers.py
+++ b/proxy/resolvers/query_resolvers.py
@@ -15,19 +15,31 @@ def fetch_stats_for_host(host, org='agh-utc', start="-1h", resolution="10s"):
             'Authorization': f'Token {INFLUXDB_TOKEN}'
         },
         json={
+            # "query": f"from(bucket: \"{host}\")\n"
+            #          f"|> range(start: {start})\n"
+            #          f"|> filter(fn: (r) => r[\"_measurement\"] == \"containers\" or r[\"_measurement\"] == \"disk\" or "
+            #             f"r[\"_measurement\"] == \"virtual_memory\")\n|> filter(fn: (r) => r[\"_field\"] == \"used\" or "
+            #             f"r[\"_field\"] == \"total\" or r[\"_field\"] == \"status\" or r[\"_field\"] == \"percent\" or "
+            #             f"r[\"_field\"] == \"name\" or r[\"_field\"] == \"memory_usage\" or r[\"_field\"] == \"image\" or "
+            #             f"r[\"_field\"] == \"id\" or r[\"_field\"] == \"cpu_percentage\")\n"
+            #          f"|> aggregateWindow(every: {resolution}, fn: last, createEmpty: false)\n|> yield(name:\"last\")"
             "query": f"from(bucket: \"{host}\")\n"
                      f"|> range(start: {start})\n"
                      f"|> filter(fn: (r) => r[\"_measurement\"] == \"containers\" or r[\"_measurement\"] == \"disk\" or "
-                        f"r[\"_measurement\"] == \"virtual_memory\")\n|> filter(fn: (r) => r[\"_field\"] == \"used\" or "
-                        f"r[\"_field\"] == \"total\" or r[\"_field\"] == \"status\" or r[\"_field\"] == \"percent\" or "
-                        f"r[\"_field\"] == \"name\" or r[\"_field\"] == \"memory_usage\" or r[\"_field\"] == \"image\" or "
-                        f"r[\"_field\"] == \"id\" or r[\"_field\"] == \"cpu_percentage\")\n"
-                     f"|> aggregateWindow(every: {resolution}, fn: last, createEmpty: false)\n|> yield(name:\"last\")"
+                     f"r[\"_measurement\"] == \"virtual_memory\")\n|> aggregateWindow(every: {resolution}, "
+                        f"fn: last, createEmpty: false)\n|> yield(name:\"last\")"
         }
     )
 
     csv_data = response.content.decode(ENCODING)
+    print(csv_data)
     reader = csv.DictReader(io.StringIO(csv_data))
-    json_data = eval(json.dumps(list(reader)))
+    json_data = []
+    for row in reader:
+        json_data.append(row)
+    print(json_data)
+    # print(list(reader))
+    # json_data = eval(json.dumps(list(reader)))
+    # print(json_data)
 
     return json_data


### PR DESCRIPTION
Changed /hosts response JSON format.

Dropped unnecessary values and changed json format:

Root keys: names of hosts (buckets)

Host keys:
- containers: list of container objects with 
  relevant stats
- disk: disk usage by host. Contains 'percent',
  'total' and 'used' keys. Each key holds an array 
  of values
- virtual_memory: RAM used by host. By analogy to 'disk'
- name: name of the host (first part of host's name)
- ip: ip of the host (second part of host's name)